### PR TITLE
feat: show working time when session is paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2025-07-19
+
+- **Paused Session Working Time**: The `flow status` command now shows how much time you've actually worked when a session is paused, excluding pause time for accurate productivity tracking.
+
 ## [1.1.3] - 2025-07-12
 
 ### Added

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -42,7 +42,17 @@ The --raw flag can be used to output only the session tag for scripting purposes
 		if session.IsPaused {
 			pausedDuration := time.Since(session.PausedAt)
 			fmt.Printf("⏸️  Session paused: %s\n", session.Tag)
-			fmt.Printf("Paused for %s. Use 'flow resume' to continue.\n", core.FormatDuration(pausedDuration))
+
+			// Calculate working time up to when the session was paused
+			workingTime := session.PausedAt.Sub(session.StartTime) - session.TotalPaused
+			if workingTime < 0 {
+				workingTime = 0
+			}
+
+			fmt.Printf("Worked for %s • Paused for %s\n",
+				core.FormatDuration(workingTime),
+				core.FormatDuration(pausedDuration))
+			fmt.Printf("Use 'flow resume' to continue or 'flow stop' to end.\n")
 		} else {
 			duration := time.Since(session.StartTime) - session.TotalPaused
 			baseMsg := fmt.Sprintf("🌊 Deep work: %s (Active for %s)", session.Tag, core.FormatDuration(duration))


### PR DESCRIPTION
 The `flow status` command now shows how much time you've actually worked when a session is paused.